### PR TITLE
fix(e2e): scope /datasets heading to .first() (Playwright strict mode)

### DIFF
--- a/e2e/tests/navigation.spec.ts
+++ b/e2e/tests/navigation.spec.ts
@@ -101,7 +101,11 @@ test.describe('Navigation', () => {
     await expect(page.getByRole('heading', { name: /settings/i })).toBeVisible({ timeout: 30000 });
 
     await page.goto('/datasets', { waitUntil: 'domcontentloaded' });
-    await expect(page.getByRole('heading', { name: /datasets/i })).toBeVisible({ timeout: 30000 });
+    // The /datasets page renders more than one heading matching /datasets/i
+    // (page title + dataset-card headings), so scope to the first like the
+    // DatasetsPage object does (e2e/pages/datasets.page.ts) — a bare match trips
+    // Playwright strict mode ("resolved to 2 elements").
+    await expect(page.getByRole('heading', { name: /datasets/i }).first()).toBeVisible({ timeout: 30000 });
 
     await page.goto('/pipelines', { waitUntil: 'domcontentloaded' });
     await expect(page.getByRole('heading', { name: 'Pipelines', exact: true })).toBeVisible({ timeout: 30000 });


### PR DESCRIPTION
## Why
`Playwright E2E Tests` fails on every recent push (cockpit shows studio's health dot red). The `should handle direct URL navigation` smoke asserts:

```ts
await expect(page.getByRole('heading', { name: /datasets/i })).toBeVisible(...)
```

The `/datasets` page renders **more than one** heading matching `/datasets/i` (page title + dataset-card headings), so Playwright **strict mode** fails: `resolved to 2 elements` (1 failed / 18 passed).

## Fix
Scope to `.first()` — exactly what the `DatasetsPage` object already does (`e2e/pages/datasets.page.ts:26`). One-line, consistent with the existing pattern.

Validated by this PR's Playwright run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)