### PR TITLE
feat(predict): expose native archive conformal replay

### DIFF
--- a/api/predict.py
+++ b/api/predict.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import io
 from pathlib import Path
+from typing import Literal
 
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 from pydantic import BaseModel, Field
@@ -34,11 +35,19 @@ class PredictRequest(BaseModel):
     """JSON request for prediction."""
 
     model_id: str = Field(..., description="Chain ID or bundle stem/path")
-    model_source: str = Field(..., description="'chain' or 'bundle'")
-    data_source: str = Field(..., description="'dataset' or 'array'")
+    model_source: Literal["chain", "bundle", "native_archive"] = Field(
+        ..., description="'chain', 'bundle', or 'native_archive'"
+    )
+    data_source: Literal["dataset", "array"] = Field(
+        ..., description="'dataset' or 'array'"
+    )
     dataset_id: str | None = Field(None, description="Dataset ID (when data_source='dataset')")
     partition: str = Field("all", description="Dataset partition (train/test/all)")
     spectra: list[list[float]] | None = Field(None, description="2D spectra array (when data_source='array')")
+    sample_ids: list[str] | None = Field(
+        None,
+        description="Exact stable sample IDs, required for native_archive predictions",
+    )
 
 
 class PredictResponse(BaseModel):
@@ -51,6 +60,7 @@ class PredictResponse(BaseModel):
     actual_values: list[float] | None = None
     metrics: dict[str, float] | None = None
     sample_ids: list[str | int] | None = None
+    conformal_presentation: dict[str, object] | None = None
     # Per-sample partition labels ("train"/"val"/"test"/...) when the request
     # ran across multiple partitions (partition="all"); None otherwise.
     partitions: list[str] | None = None
@@ -65,6 +75,7 @@ def _run_prediction(
     X,
     y_true=None,
     partitions: list[str] | None = None,
+    sample_ids: list[str] | None = None,
 ) -> PredictResponse:
     """Execute prediction using nirs4all.predict()."""
     import numpy as np
@@ -84,17 +95,35 @@ def _run_prediction(
                 workspace_path=str(workspace_path) if workspace_path else None,
                 verbose=0,
             )
-        else:
+        elif model_source == "bundle":
             bundle_path = str(_resolve_bundle_path(model_id))
             pred_result = nirs4all.predict(model=bundle_path, data=X, verbose=0)
+        elif model_source == "native_archive":
+            stable_ids = _require_native_sample_ids(sample_ids, len(X))
+            archive_path = str(_resolve_bundle_path(model_id))
+            pred_result = nirs4all.predict(
+                model=archive_path,
+                data={"X": X, "sample_ids": stable_ids},
+                engine="native",
+                verbose=0,
+            )
+        else:
+            raise HTTPException(status_code=422, detail=f"Unknown model source: {model_source}")
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"Model '{model_id}' not found")
+    except HTTPException:
+        raise
     except ValueError as e:
         raise HTTPException(
             status_code=422,
             detail=f"Prediction data is incompatible with model '{model_id}': {e}",
         ) from e
     except Exception as e:
+        if model_source == "native_archive":
+            raise HTTPException(
+                status_code=422,
+                detail="Native archive prediction was refused before a result could be produced",
+            ) from e
         raise HTTPException(status_code=500, detail=f"Prediction failed: {str(e)}")
 
     # Extract predictions
@@ -145,6 +174,37 @@ def _run_prediction(
         elif len(partitions) > len(predictions):
             aligned_partitions = list(partitions[: len(predictions)])
 
+    result_metadata = getattr(pred_result, "metadata", None)
+    native_sample_ids = (
+        result_metadata.get("sample_ids")
+        if isinstance(result_metadata, dict)
+        else None
+    )
+    response_sample_ids = (
+        native_sample_ids
+        if isinstance(native_sample_ids, list)
+        and len(native_sample_ids) == len(predictions)
+        and all(isinstance(value, str) and value for value in native_sample_ids)
+        else None
+    )
+    conformal_presentation = (
+        result_metadata.get("conformal_presentation")
+        if isinstance(result_metadata, dict)
+        and isinstance(result_metadata.get("conformal_presentation"), dict)
+        else None
+    )
+    if conformal_presentation is not None:
+        presentation_sample_ids = conformal_presentation.get("sample_ids")
+        if (
+            response_sample_ids is None
+            or not isinstance(presentation_sample_ids, list)
+            or presentation_sample_ids != response_sample_ids
+        ):
+            raise HTTPException(
+                status_code=422,
+                detail="Native conformal presentation identities do not exactly match prediction identities",
+            )
+
     return PredictResponse(
         predictions=predictions,
         num_samples=len(predictions),
@@ -152,8 +212,30 @@ def _run_prediction(
         preprocessing_steps=preprocessing_steps,
         actual_values=actual_values,
         metrics=metrics,
+        sample_ids=response_sample_ids,
+        conformal_presentation=conformal_presentation,
         partitions=aligned_partitions,
     )
+
+
+def _require_native_sample_ids(
+    sample_ids: list[str] | None,
+    expected_count: int,
+) -> list[str]:
+    """Require explicit, unique IDs before crossing the native archive boundary."""
+
+    if (
+        not isinstance(sample_ids, list)
+        or len(sample_ids) != expected_count
+        or not sample_ids
+        or not all(isinstance(sample_id, str) and sample_id for sample_id in sample_ids)
+        or len(set(sample_ids)) != len(sample_ids)
+    ):
+        raise HTTPException(
+            status_code=422,
+            detail="native_archive prediction requires one unique non-empty string sample_id per spectrum",
+        )
+    return list(sample_ids)
 
 
 # ============= Endpoints =============
@@ -253,12 +335,19 @@ async def predict(request: PredictRequest):
     else:
         raise HTTPException(status_code=400, detail=f"Unknown data_source: {request.data_source}")
 
+    if request.model_source == "native_archive" and request.data_source != "array":
+        raise HTTPException(
+            status_code=422,
+            detail="native_archive prediction currently requires an array cohort with explicit sample_ids",
+        )
+
     return _run_prediction(
         request.model_id,
         request.model_source,
         X,
         y_true,
         partitions=per_sample_partitions,
+        sample_ids=request.sample_ids,
     )
 
 
@@ -319,6 +408,16 @@ async def predict_from_file(
     else:
         sample_ids = list(range(len(df)))
 
-    result = _run_prediction(model_id, model_source, X)
+    if model_source == "native_archive" and not non_numeric:
+        raise HTTPException(
+            status_code=422,
+            detail="native_archive file prediction requires a non-numeric column containing stable sample IDs",
+        )
+    result = _run_prediction(
+        model_id,
+        model_source,
+        X,
+        sample_ids=sample_ids if model_source == "native_archive" else None,
+    )
     result.sample_ids = sample_ids
     return result

--- a/src/types/predict.ts
+++ b/src/types/predict.ts
@@ -27,11 +27,31 @@ export interface AvailableModelsResponse {
 
 export interface PredictRequest {
   model_id: string;
-  model_source: "chain" | "bundle";
+  model_source: "chain" | "bundle" | "native_archive";
   data_source: "dataset" | "array";
   dataset_id?: string;
   partition?: string;
   spectra?: number[][];
+  /** Required by the fail-closed native Archive V2 route. */
+  sample_ids?: string[];
+}
+
+export interface NativeConformalPresentation {
+  schema_version: 1;
+  package_fingerprint: string;
+  replay_outcome_fingerprint: string;
+  binding_id: string;
+  target_name: string;
+  sample_ids: string[];
+  point_predictions: number[];
+  intervals: Array<{
+    coverage: number;
+    lower: Array<number | null>;
+    upper: Array<number | null>;
+    qhat: number | null;
+  }>;
+  calibration_fingerprint: string;
+  presentation_fingerprint: string;
 }
 
 export interface PredictResponse {
@@ -42,6 +62,7 @@ export interface PredictResponse {
   actual_values: number[] | null;
   metrics: Record<string, number> | null;
   sample_ids: (string | number)[] | null;
+  conformal_presentation?: NativeConformalPresentation | null;
   /** When the request was `partition: "all"`, backend returns per-sample
    *  partition labels ("train"/"val"/"test") so charts can split by partition. */
   partitions?: (string | null)[] | null;

--- a/tests/test_predict_metrics.py
+++ b/tests/test_predict_metrics.py
@@ -57,6 +57,29 @@ class _FailingNirs4all:
         )
 
 
+class _NativeArchiveResult:
+    y_pred = np.asarray([[1.5], [2.5]], dtype=float)
+    model_name = "MethodsN4MM"
+    preprocessing_steps: list[str] = []
+    metadata = {
+        "sample_ids": ["sample.one", "sample.two"],
+        "conformal_presentation": {
+            "schema_version": 1,
+            "sample_ids": ["sample.one", "sample.two"],
+            "point_predictions": [1.5, 2.5],
+        },
+    }
+
+
+class _NativeArchiveNirs4all:
+    def __init__(self) -> None:
+        self.kwargs: dict | None = None
+
+    def predict(self, **kwargs):
+        self.kwargs = kwargs
+        return _NativeArchiveResult()
+
+
 def _fake_get_cached_factory(
     *,
     y_pred,
@@ -242,3 +265,92 @@ def test_run_prediction_returns_422_for_incompatible_model_data(monkeypatch):
     assert exc_info.value.status_code == 422
     assert "incompatible" in exc_info.value.detail
     assert "(60,2151)" in exc_info.value.detail
+
+
+def test_native_archive_prediction_requires_exact_ids_and_transports_owner_presentation(monkeypatch):
+    native = _NativeArchiveNirs4all()
+    monkeypatch.setattr(
+        predict_mod,
+        "get_cached",
+        lambda key, **kwargs: native if key == "nirs4all" else None,
+    )
+    monkeypatch.setattr(
+        predict_mod,
+        "_resolve_bundle_path",
+        lambda model_id: f"/exports/{model_id}.n4a",
+    )
+    monkeypatch.setattr(
+        predict_mod.workspace_manager, "get_current_workspace", lambda: None
+    )
+
+    response = predict_mod._run_prediction(
+        "portable",
+        "native_archive",
+        np.asarray([[1.0], [2.0]]),
+        sample_ids=["sample.one", "sample.two"],
+    )
+
+    assert native.kwargs is not None
+    assert native.kwargs["model"] == "/exports/portable.n4a"
+    np.testing.assert_allclose(native.kwargs["data"]["X"], [[1.0], [2.0]])
+    assert native.kwargs["data"]["sample_ids"] == ["sample.one", "sample.two"]
+    assert native.kwargs["engine"] == "native"
+    assert native.kwargs["verbose"] == 0
+    assert response.sample_ids == ["sample.one", "sample.two"]
+    assert response.conformal_presentation == _NativeArchiveResult.metadata["conformal_presentation"]
+
+
+@pytest.mark.parametrize("sample_ids", [None, ["same", "same"], ["only-one"], ["", "sample.two"]])
+def test_native_archive_prediction_refuses_missing_or_noncanonical_ids(monkeypatch, sample_ids):
+    native = _NativeArchiveNirs4all()
+    monkeypatch.setattr(
+        predict_mod,
+        "get_cached",
+        lambda key, **kwargs: native if key == "nirs4all" else None,
+    )
+
+    with pytest.raises(HTTPException) as error:
+        predict_mod._run_prediction(
+            "portable",
+            "native_archive",
+            np.asarray([[1.0], [2.0]]),
+            sample_ids=sample_ids,
+        )
+
+    assert error.value.status_code == 422
+    assert native.kwargs is None
+
+
+def test_native_archive_prediction_refuses_misaligned_conformal_presentation(monkeypatch):
+    class MisalignedNative:
+        def predict(self, **_kwargs):
+            result = _NativeArchiveResult()
+            result.metadata = {
+                **result.metadata,
+                "conformal_presentation": {
+                    **result.metadata["conformal_presentation"],
+                    "sample_ids": ["sample.two", "sample.one"],
+                },
+            }
+            return result
+
+    monkeypatch.setattr(
+        predict_mod,
+        "get_cached",
+        lambda key, **kwargs: MisalignedNative() if key == "nirs4all" else None,
+    )
+    monkeypatch.setattr(
+        predict_mod,
+        "_resolve_bundle_path",
+        lambda model_id: f"/exports/{model_id}.n4a",
+    )
+
+    with pytest.raises(HTTPException, match="identities") as error:
+        predict_mod._run_prediction(
+            "portable",
+            "native_archive",
+            np.asarray([[1.0], [2.0]]),
+            sample_ids=["sample.one", "sample.two"],
+        )
+
+    assert error.value.status_code == 422


### PR DESCRIPTION
## Summary

- add an explicit, fail-closed `native_archive` prediction source to Studio
- require exact unique string sample IDs before invoking `nirs4all` with `engine="native"`
- transport DAG-ML conformal presentation metadata and reject mismatched identity order

The route does not calculate metrics, intervals, or conformal quantities.

## Validation

- `python3.11 -m ruff check api/predict.py tests/test_predict_metrics.py`
- `pytest -q tests/test_predict_metrics.py`
- `git diff --check`

## Environment

Node is unavailable in this Linux environment, so the TypeScript check remains for CI.