### PR TITLE
feat(predict): render native conformal bounds

### DIFF
--- a/src/components/predict/PredictResultsTable.tsx
+++ b/src/components/predict/PredictResultsTable.tsx
@@ -27,6 +27,10 @@ export function PredictResultsTable({
   showPartitionColumn,
 }: PredictResultsTableProps) {
   const { t } = useTranslation();
+  const conformalCoverageLabel = rows.find(
+    (row) => row.conformalCoverageLabel,
+  )?.conformalCoverageLabel;
+  const hasConformalBounds = conformalCoverageLabel !== undefined;
 
   return (
     <div className="max-h-[460px] overflow-auto rounded-md border">
@@ -42,6 +46,12 @@ export function PredictResultsTable({
             <TableHead className="text-right">
               {t("predict.results.table.predicted")}
             </TableHead>
+            {hasConformalBounds && (
+              <>
+                <TableHead className="text-right">{conformalCoverageLabel} lower</TableHead>
+                <TableHead className="text-right">{conformalCoverageLabel} upper</TableHead>
+              </>
+            )}
             {hasActuals && (
               <>
                 <TableHead className="text-right">
@@ -66,6 +76,16 @@ export function PredictResultsTable({
               <TableCell className="text-right font-mono text-sm">
                 {formatMetricValue(row.predicted)}
               </TableCell>
+              {hasConformalBounds && (
+                <>
+                  <TableCell className="text-right font-mono text-sm">
+                    {row.conformalLower !== undefined ? formatMetricValue(row.conformalLower) : "–"}
+                  </TableCell>
+                  <TableCell className="text-right font-mono text-sm">
+                    {row.conformalUpper !== undefined ? formatMetricValue(row.conformalUpper) : "–"}
+                  </TableCell>
+                </>
+              )}
               {hasActuals && (
                 <>
                   <TableCell className="text-right font-mono text-sm">

--- a/src/components/predict/__tests__/predictResultsData.test.ts
+++ b/src/components/predict/__tests__/predictResultsData.test.ts
@@ -81,6 +81,101 @@ describe("predictResultsData", () => {
     ]);
   });
 
+  it("attaches the exact native conformal presentation without recomputing bounds", () => {
+    const [dataset] = buildPredictPartitionDatasets({
+      fallbackPartition: "pred",
+      hasActuals: false,
+      result: response({
+        predictions: [1.1, 2.2, 3.3],
+        actual_values: null,
+        conformal_presentation: {
+          schema_version: 1,
+          package_fingerprint: "a".repeat(64),
+          replay_outcome_fingerprint: "b".repeat(64),
+          binding_id: "binding:pls",
+          target_name: "moisture",
+          sample_ids: ["a", "b", "c"],
+          point_predictions: [1.1, 2.2, 3.3],
+          intervals: [
+            {
+              coverage: 0.9,
+              lower: [0.9, null, 3.1],
+              upper: [1.3, null, 3.5],
+              qhat: 0.2,
+            },
+          ],
+          calibration_fingerprint: "c".repeat(64),
+          presentation_fingerprint: "d".repeat(64),
+        },
+      }),
+    });
+
+    expect(dataset.conformalCoverage).toBe(0.9);
+    expect(dataset.conformalCoverageLabel).toBe("90%");
+    expect(dataset.conformalIntervals).toEqual([
+      { coverage: 0.9, coverageLabel: "90%", lower: 0.9, upper: 1.3 },
+      null,
+      { coverage: 0.9, coverageLabel: "90%", lower: 3.1, upper: 3.5 },
+    ]);
+    const rows = buildPredictTableRows(
+      response({
+        predictions: [1.1, 2.2, 3.3],
+        actual_values: null,
+        conformal_presentation: {
+          schema_version: 1,
+          package_fingerprint: "a".repeat(64),
+          replay_outcome_fingerprint: "b".repeat(64),
+          binding_id: "binding:pls",
+          target_name: "moisture",
+          sample_ids: ["a", "b", "c"],
+          point_predictions: [1.1, 2.2, 3.3],
+          intervals: [
+            { coverage: 0.9, lower: [0.9, null, 3.1], upper: [1.3, null, 3.5], qhat: 0.2 },
+          ],
+          calibration_fingerprint: "c".repeat(64),
+          presentation_fingerprint: "d".repeat(64),
+        },
+      }),
+      false,
+    );
+    expect(rows[0]).toMatchObject({
+      conformalCoverageLabel: "90%",
+      conformalLower: 0.9,
+      conformalUpper: 1.3,
+    });
+    expect(rows[1].conformalLower).toBeUndefined();
+    expect(buildPredictTableCsvRows(rows)[0]).toMatchObject({
+      conformal_lower: 0.9,
+      conformal_upper: 1.3,
+    });
+  });
+
+  it("refuses a native conformal presentation with misaligned identities or points", () => {
+    const [dataset] = buildPredictPartitionDatasets({
+      fallbackPartition: "pred",
+      hasActuals: false,
+      result: response({
+        conformal_presentation: {
+          schema_version: 1,
+          package_fingerprint: "a".repeat(64),
+          replay_outcome_fingerprint: "b".repeat(64),
+          binding_id: "binding:pls",
+          target_name: "moisture",
+          sample_ids: ["b", "a", "c"],
+          point_predictions: [1.1, 2.2, 3.3],
+          intervals: [
+            { coverage: 0.9, lower: [0.9, 2.0, 3.1], upper: [1.3, 2.4, 3.5], qhat: 0.2 },
+          ],
+          calibration_fingerprint: "c".repeat(64),
+          presentation_fingerprint: "d".repeat(64),
+        },
+      }),
+    });
+
+    expect(dataset.conformalIntervals).toBeUndefined();
+    expect(dataset.conformalCoverage).toBeUndefined();
+  });
+
   it("derives available and default chart kinds", () => {
     expect(buildPredictAvailableKinds(false, "regression")).toEqual(["distribution"]);
     expect(buildPredictAvailableKinds(true, "regression")).toEqual(["scatter", "residuals", "distribution"]);

--- a/src/components/predict/predictResultsData.ts
+++ b/src/components/predict/predictResultsData.ts
@@ -71,6 +71,9 @@ export interface PredictTableRow {
   index: string | number;
   partition: string | null;
   predicted: number;
+  conformalCoverageLabel?: string;
+  conformalLower?: number;
+  conformalUpper?: number;
   actual?: number;
   residual?: number;
 }
@@ -78,6 +81,17 @@ export interface PredictTableRow {
 export interface PredictCsvExport {
   columns: string[];
   rows: Record<string, unknown>[];
+}
+
+interface NativeConformalAttachment {
+  coverage: number;
+  coverageLabel: string;
+  intervals: Array<{
+    coverage: number;
+    coverageLabel: string;
+    lower: number;
+    upper: number;
+  } | null>;
 }
 
 const PARTITION_ORDER: Record<string, number> = {
@@ -261,6 +275,7 @@ export function buildPredictPartitionDatasets({
 }): PartitionDataset[] {
   const n = result.predictions.length;
   const perSample = result.partitions ?? null;
+  const conformal = resolveNativeConformalAttachment(result);
 
   if (perSample && perSample.length === n && new Set(perSample.filter(Boolean)).size > 1) {
     const groups = new Map<string, number[]>();
@@ -288,6 +303,11 @@ export function buildPredictPartitionDatasets({
         yPred: indices.map((index) => result.predictions[index]),
         nSamples: indices.length,
         sampleIds: indices.map((index) => result.sample_ids?.[index] ?? index + 1),
+        conformalCoverage: conformal?.coverage,
+        conformalCoverageLabel: conformal?.coverageLabel,
+        conformalIntervals: conformal
+          ? indices.map((index) => conformal.intervals[index])
+          : undefined,
       };
     });
   }
@@ -302,8 +322,71 @@ export function buildPredictPartitionDatasets({
       yPred: result.predictions,
       nSamples: n,
       sampleIds: result.predictions.map((_, index) => result.sample_ids?.[index] ?? index + 1),
+      conformalCoverage: conformal?.coverage,
+      conformalCoverageLabel: conformal?.coverageLabel,
+      conformalIntervals: conformal?.intervals,
     },
   ];
+}
+
+/**
+ * Convert the scalar presentation emitted by DAG-ML into the shared chart view.
+ *
+ * This is deliberately a transport validation, not an interval calculation:
+ * every identity, point prediction, and finite endpoint must already close over
+ * the native response before the chart can display a band.
+ */
+function resolveNativeConformalAttachment(result: PredictResponse): NativeConformalAttachment | null {
+  const presentation = result.conformal_presentation;
+  const sampleIds = result.sample_ids;
+  if (
+    !presentation
+    || presentation.schema_version !== 1
+    || !Array.isArray(sampleIds)
+    || !sampleIds.every((sampleId): sampleId is string => typeof sampleId === "string" && sampleId.length > 0)
+    || sampleIds.length !== result.predictions.length
+    || presentation.sample_ids.length !== sampleIds.length
+    || presentation.point_predictions.length !== result.predictions.length
+    || presentation.sample_ids.some((sampleId, index) => sampleId !== sampleIds[index])
+    || presentation.point_predictions.some((value, index) => !Object.is(value, result.predictions[index]))
+    || presentation.intervals.length === 0
+  ) {
+    return null;
+  }
+
+  const interval = presentation.intervals[0];
+  if (
+    !Number.isFinite(interval.coverage)
+    || interval.coverage <= 0
+    || interval.coverage >= 1
+    || interval.lower.length !== sampleIds.length
+    || interval.upper.length !== sampleIds.length
+  ) {
+    return null;
+  }
+  const coverageLabel = `${Math.round(interval.coverage * 1000) / 10}%`;
+  const intervals: NativeConformalAttachment["intervals"] = [];
+  for (let index = 0; index < sampleIds.length; index++) {
+    const lower = interval.lower[index];
+    const upper = interval.upper[index];
+    const point = result.predictions[index];
+    if (lower === null || upper === null) {
+      if (lower !== null || upper !== null) return null;
+      intervals.push(null);
+      continue;
+    }
+    if (
+      !Number.isFinite(lower)
+      || !Number.isFinite(upper)
+      || !Number.isFinite(point)
+      || lower > point
+      || point > upper
+    ) {
+      return null;
+    }
+    intervals.push({ coverage: interval.coverage, coverageLabel, lower, upper });
+  }
+  return { coverage: interval.coverage, coverageLabel, intervals };
 }
 
 export function getPredictInputLabel(input: PredictionInput | null | undefined, fallback: string): string {
@@ -348,16 +431,27 @@ export function resolvePredictDefaultKind(
 }
 
 export function buildPredictTableRows(result: PredictResponse, hasActuals: boolean): PredictTableRow[] {
-  return result.predictions.map((prediction, index) => ({
-    index: result.sample_ids?.[index] ?? index + 1,
-    partition:
-      result.partitions && result.partitions.length === result.predictions.length
-        ? result.partitions[index]
-        : null,
-    predicted: prediction,
-    actual: hasActuals ? result.actual_values![index] : undefined,
-    residual: hasActuals ? result.actual_values![index] - prediction : undefined,
-  }));
+  const conformal = resolveNativeConformalAttachment(result);
+  return result.predictions.map((prediction, index) => {
+    const interval = conformal?.intervals[index];
+    return {
+      index: result.sample_ids?.[index] ?? index + 1,
+      partition:
+        result.partitions && result.partitions.length === result.predictions.length
+          ? result.partitions[index]
+          : null,
+      predicted: prediction,
+      ...(interval
+        ? {
+            conformalCoverageLabel: interval.coverageLabel,
+            conformalLower: interval.lower,
+            conformalUpper: interval.upper,
+          }
+        : {}),
+      actual: hasActuals ? result.actual_values![index] : undefined,
+      residual: hasActuals ? result.actual_values![index] - prediction : undefined,
+    };
+  });
 }
 
 export function buildPredictMetricEntries(metrics: Record<string, number> | null): PredictMetricEntry[] {
@@ -484,6 +578,8 @@ export function buildPredictTableCsvRows(tableRows: PredictTableRow[]): Record<s
       predicted: row.predicted,
     };
     if (row.partition) record.partition = row.partition;
+    if (row.conformalLower !== undefined) record.conformal_lower = row.conformalLower;
+    if (row.conformalUpper !== undefined) record.conformal_upper = row.conformalUpper;
     if (row.actual !== undefined) record.actual = row.actual;
     if (row.residual !== undefined) record.residual = row.residual;
     return record;


### PR DESCRIPTION
## Summary
- render server-attested native conformal bounds in prediction tables and CSV exports
- preserve exact response IDs, points, and endpoints; refuse unaligned presentations
- add targeted presentation transport tests

## Validation
- TypeScript no-emit check
- ESLint on touched files
- Vitest predictResultsData test: 11 passed
- git diff --check