### PR TITLE
feat(predict): select native archive models

### DIFF
--- a/src/components/predict/DataInput.tsx
+++ b/src/components/predict/DataInput.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   ClipboardPaste,
@@ -71,18 +71,25 @@ export function DataInput({ model, isLoading, onRunPrediction }: DataInputProps)
   const { data: datasetsData } = useDatasetsQuery();
   const datasets = datasetsData?.datasets ?? [];
   const isModelSelected = model != null;
-  const sourceTabs = buildDataInputSourceTabs(isModelSelected);
+  const sourceTabs = buildDataInputSourceTabs(isModelSelected, model?.source);
   const modelReadModel = buildDataInputModelReadModel(model);
   const datasetReadModel = buildDataInputDatasetReadModel(datasets);
   const fileReadModel = buildDataInputFileReadModel(file);
   const canSubmit = getDataInputCanSubmit({
     isModelSelected,
+    modelSource: model?.source,
     isLoading,
     tab,
     datasetId,
     file,
     pasteText,
   });
+
+  useEffect(() => {
+    if (model?.source === "native_archive") {
+      setTab("upload");
+    }
+  }, [model?.source]);
 
   const handleFileDrop = useCallback((event: React.DragEvent) => {
     event.preventDefault();
@@ -126,7 +133,11 @@ export function DataInput({ model, isLoading, onRunPrediction }: DataInputProps)
         <div>
           <CardTitle>{t("predict.data.title")}</CardTitle>
           <p className="mt-1 text-sm text-muted-foreground">
-            {t("predict.data.description")}
+            {model?.source === "native_archive"
+              ? t("predict.data.nativeArchive.description", {
+                  defaultValue: "Native archives require an uploaded CSV or Excel file with a non-numeric stable sample-ID column.",
+                })
+              : t("predict.data.description")}
           </p>
         </div>
 

--- a/src/components/predict/DataInputData.ts
+++ b/src/components/predict/DataInputData.ts
@@ -35,6 +35,7 @@ export interface DataInputPartitionOption {
 
 export interface DataInputCanSubmitInput {
   isModelSelected: boolean;
+  modelSource?: AvailableModel["source"] | null;
   isLoading: boolean;
   tab: DataInputTab;
   datasetId: string;
@@ -114,10 +115,13 @@ const ACCEPTED_DATA_INPUT_EXTENSIONS = [".csv", ".xlsx", ".xls"] as const;
 const MODEL_SCORE_PILL_CLASS = "rounded-full bg-background px-2.5 py-1 font-medium text-foreground";
 const MODEL_METADATA_PILL_CLASS = "rounded-full bg-background px-2.5 py-1 text-muted-foreground";
 
-export function buildDataInputSourceTabs(isModelSelected: boolean): DataInputSourceTab[] {
+export function buildDataInputSourceTabs(
+  isModelSelected: boolean,
+  modelSource?: AvailableModel["source"] | null,
+): DataInputSourceTab[] {
   return DATA_INPUT_SOURCE_DEFINITIONS.map((source) => ({
     ...source,
-    disabled: !isModelSelected,
+    disabled: !isModelSelected || (modelSource === "native_archive" && source.id !== "upload"),
   }));
 }
 
@@ -171,6 +175,7 @@ export function parsePastedSpectra(text: string): number[][] | null {
 
 export function getDataInputCanSubmit(input: DataInputCanSubmitInput): boolean {
   if (!input.isModelSelected || input.isLoading) return false;
+  if (input.modelSource === "native_archive" && input.tab !== "upload") return false;
   if (input.tab === "dataset") return Boolean(input.datasetId);
   if (input.tab === "upload") return Boolean(input.file);
   if (input.tab === "paste") return Boolean(input.pasteText.trim());

--- a/src/components/predict/ModelSelector.tsx
+++ b/src/components/predict/ModelSelector.tsx
@@ -1,11 +1,16 @@
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useQuery } from "@tanstack/react-query";
+import { Archive, FolderOpen } from "lucide-react";
 
 import { getAvailableModels } from "@/api/predict";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 import type { AvailableModel } from "@/types/predict";
+import { selectFile } from "@/utils/fileDialogs";
 import {
+  buildNativeArchiveModel,
   buildModelSelectorState,
   hasHydratedModel,
   type SortField,
@@ -22,6 +27,80 @@ import {
 interface ModelSelectorProps {
   selectedModel: AvailableModel | null;
   onSelect: (model: AvailableModel) => void;
+}
+
+function NativeArchivePicker({ onSelect }: Pick<ModelSelectorProps, "onSelect">) {
+  const { t } = useTranslation();
+  const [path, setPath] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const selectArchive = () => {
+    const model = buildNativeArchiveModel(path);
+    if (!model) {
+      setError(t("predict.model.nativeArchive.invalid", {
+        defaultValue: "Choose a .n4a native archive first.",
+      }));
+      return;
+    }
+    setError(null);
+    onSelect(model);
+  };
+
+  const openArchivePicker = async () => {
+    const selected = await selectFile([".n4a"]);
+    const selectedPath = Array.isArray(selected) ? selected[0] : selected;
+    if (typeof selectedPath === "string") {
+      setPath(selectedPath);
+      setError(null);
+      const model = buildNativeArchiveModel(selectedPath);
+      if (model) onSelect(model);
+    }
+  };
+
+  return (
+    <Card className="border-primary/25 bg-primary/[0.03] shadow-sm">
+      <CardContent className="space-y-3 p-4">
+        <div className="flex items-start gap-3">
+          <div className="mt-0.5 rounded-md bg-primary/10 p-2 text-primary">
+            <Archive className="h-4 w-4" aria-hidden="true" />
+          </div>
+          <div>
+            <p className="text-sm font-semibold">
+              {t("predict.model.nativeArchive.title", { defaultValue: "Native Archive V2" })}
+            </p>
+            <p className="text-xs leading-5 text-muted-foreground">
+              {t("predict.model.nativeArchive.description", {
+                defaultValue: "Select a portable Methods archive. Prediction stays on the native replay path.",
+              })}
+            </p>
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <Input
+            aria-label={t("predict.model.nativeArchive.path", { defaultValue: "Native Archive V2 path" })}
+            placeholder={t("predict.model.nativeArchive.placeholder", { defaultValue: "/path/to/model.n4a" })}
+            value={path}
+            onChange={(event) => setPath(event.target.value)}
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            onClick={() => void openArchivePicker()}
+          >
+            <FolderOpen className="h-4 w-4" aria-hidden="true" />
+            <span className="sr-only">
+              {t("predict.model.nativeArchive.choose", { defaultValue: "Choose native archive" })}
+            </span>
+          </Button>
+          <Button type="button" onClick={selectArchive}>
+            {t("predict.model.nativeArchive.use", { defaultValue: "Use archive" })}
+          </Button>
+        </div>
+        {error && <p className="text-xs text-destructive">{error}</p>}
+      </CardContent>
+    </Card>
+  );
 }
 
 export function ModelSelector({ selectedModel, onSelect }: ModelSelectorProps) {
@@ -84,67 +163,79 @@ export function ModelSelector({ selectedModel, onSelect }: ModelSelectorProps) {
   };
 
   const title = t("predict.model.title");
+  const nativeArchivePicker = <NativeArchivePicker onSelect={onSelect} />;
 
   if (isLoading) {
-    return <ModelSelectorLoadingCard title={title} />;
+    return (
+      <div className="space-y-3">
+        {nativeArchivePicker}
+        <ModelSelectorLoadingCard title={title} />
+      </div>
+    );
   }
 
   if (models.length === 0) {
     return (
-      <ModelSelectorNoModelsCard
-        title={title}
-        message={t("predict.model.noModels")}
-        hint={t("predict.model.noModelsHint")}
-      />
+      <div className="space-y-3">
+        {nativeArchivePicker}
+        <ModelSelectorNoModelsCard
+          title={title}
+          message={t("predict.model.noModels")}
+          hint={t("predict.model.noModelsHint")}
+        />
+      </div>
     );
   }
 
   return (
-    <Card className="border-border/60 shadow-sm overflow-hidden">
-      <ModelSelectorHeader
-        title={title}
-        searchPlaceholder={t("predict.model.search")}
-        selectedModel={selectedModel}
-        modelCount={models.length}
-        filteredModelCount={sortedModels.length}
-        datasetOptions={datasetOptions}
-        classOptions={classOptions}
-        search={search}
-        onSearchChange={setSearch}
-        sortField={sortField}
-        sortDesc={sortDesc}
-        onSortFieldChange={setSortField}
-        onSortDescToggle={() => setSortDesc((value) => !value)}
-        taskFilter={taskFilter}
-        onTaskFilterChange={setTaskFilter}
-        taskCounts={taskCounts}
-        datasetFilter={datasetFilter}
-        onDatasetFilterChange={setDatasetFilter}
-        classFilter={classFilter}
-        onClassFilterChange={setClassFilter}
-        refitOnly={refitOnly}
-        onRefitOnlyToggle={() => setRefitOnly((value) => !value)}
-        activeFilterCount={activeFilterCount}
-        onClearFilters={clearFilters}
-      />
+    <div className="space-y-3">
+      {nativeArchivePicker}
+      <Card className="border-border/60 shadow-sm overflow-hidden">
+        <ModelSelectorHeader
+          title={title}
+          searchPlaceholder={t("predict.model.search")}
+          selectedModel={selectedModel}
+          modelCount={models.length}
+          filteredModelCount={sortedModels.length}
+          datasetOptions={datasetOptions}
+          classOptions={classOptions}
+          search={search}
+          onSearchChange={setSearch}
+          sortField={sortField}
+          sortDesc={sortDesc}
+          onSortFieldChange={setSortField}
+          onSortDescToggle={() => setSortDesc((value) => !value)}
+          taskFilter={taskFilter}
+          onTaskFilterChange={setTaskFilter}
+          taskCounts={taskCounts}
+          datasetFilter={datasetFilter}
+          onDatasetFilterChange={setDatasetFilter}
+          classFilter={classFilter}
+          onClassFilterChange={setClassFilter}
+          refitOnly={refitOnly}
+          onRefitOnlyToggle={() => setRefitOnly((value) => !value)}
+          activeFilterCount={activeFilterCount}
+          onClearFilters={clearFilters}
+        />
 
-      <CardContent className="pt-0">
-        {sortedModels.length === 0 ? (
-          <ModelSelectorEmptyResults
-            activeFilterCount={activeFilterCount}
-            onClearFilters={clearFilters}
-          />
-        ) : (
-          <ModelList
-            models={sortedModels}
-            scoreCohort={scoreCohort}
-            selectedModel={selectedModel}
-            sortField={sortField}
-            sortDesc={sortDesc}
-            onSelect={onSelect}
-          />
-        )}
-      </CardContent>
-    </Card>
+        <CardContent className="pt-0">
+          {sortedModels.length === 0 ? (
+            <ModelSelectorEmptyResults
+              activeFilterCount={activeFilterCount}
+              onClearFilters={clearFilters}
+            />
+          ) : (
+            <ModelList
+              models={sortedModels}
+              scoreCohort={scoreCohort}
+              selectedModel={selectedModel}
+              sortField={sortField}
+              sortDesc={sortDesc}
+              onSelect={onSelect}
+            />
+          )}
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/src/components/predict/ModelSelectorData.ts
+++ b/src/components/predict/ModelSelectorData.ts
@@ -43,6 +43,32 @@ export interface ModelSelectorState {
   activeFilterCount: number;
 }
 
+/**
+ * Build the explicit, user-selected Archive V2 model reference.
+ *
+ * Native archives are intentionally not inferred from legacy bundle metadata:
+ * the archive path is selected by the user and the native owner validates it
+ * before any prediction input is consumed.
+ */
+export function buildNativeArchiveModel(archivePath: string): AvailableModel | null {
+  const path = archivePath.trim();
+  if (!path || !path.toLowerCase().endsWith(".n4a")) return null;
+  const name = path.split(/[\\/]/).pop() || path;
+  return {
+    id: path,
+    name,
+    source: "native_archive",
+    model_class: "Native Archive V2",
+    dataset_name: null,
+    metric: null,
+    best_score: null,
+    created_at: null,
+    file_size: null,
+    preprocessing: null,
+    bundle_path: path,
+  };
+}
+
 export function inferTaskKind(model: AvailableModel): TaskKind {
   const metric = (model.prediction_metric || model.metric || "").toLowerCase();
   if (!metric) return "unknown";

--- a/src/components/predict/__tests__/DataInputData.test.ts
+++ b/src/components/predict/__tests__/DataInputData.test.ts
@@ -42,6 +42,11 @@ describe("DataInputData", () => {
       ["upload", false],
       ["paste", false],
     ]);
+    expect(buildDataInputSourceTabs(true, "native_archive").map((source) => [source.id, source.disabled])).toEqual([
+      ["dataset", true],
+      ["upload", false],
+      ["paste", true],
+    ]);
   });
 
   it("builds dataset, partition, and file labels", () => {
@@ -94,6 +99,18 @@ describe("DataInputData", () => {
     expect(getDataInputCanSubmit({ ...base, tab: "dataset", datasetId: "d1" })).toBe(true);
     expect(getDataInputCanSubmit({ ...base, tab: "upload", file: { name: "spectra.csv" } as File })).toBe(true);
     expect(getDataInputCanSubmit({ ...base, tab: "paste", pasteText: "1,2,3" })).toBe(true);
+    expect(getDataInputCanSubmit({
+      ...base,
+      modelSource: "native_archive",
+      tab: "dataset",
+      datasetId: "d1",
+    })).toBe(false);
+    expect(getDataInputCanSubmit({
+      ...base,
+      modelSource: "native_archive",
+      tab: "upload",
+      file: { name: "spectra.csv" } as File,
+    })).toBe(true);
   });
 
   it("builds submit configs for dataset, file, and pasted arrays", () => {

--- a/src/components/predict/__tests__/ModelSelectorData.test.ts
+++ b/src/components/predict/__tests__/ModelSelectorData.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildModelSelectorState,
+  buildNativeArchiveModel,
   formatModelFileSize,
   formatRelativeModelDate,
   getEffectiveScore,
@@ -30,6 +31,17 @@ function model(overrides: Partial<AvailableModel> = {}): AvailableModel {
 }
 
 describe("ModelSelectorData", () => {
+  it("creates an explicit native Archive V2 selection only for .n4a paths", () => {
+    expect(buildNativeArchiveModel("  C:\\models\\native.n4a  ")).toMatchObject({
+      id: "C:\\models\\native.n4a",
+      name: "native.n4a",
+      source: "native_archive",
+      model_class: "Native Archive V2",
+    });
+    expect(buildNativeArchiveModel("model.zip")).toBeNull();
+    expect(buildNativeArchiveModel(" ")).toBeNull();
+  });
+
   it("infers task kind and prefers prediction scores over selection scores", () => {
     const regression = model({ metric: "rmse", best_score: 0.2 });
     const classification = model({

--- a/src/pages/Predict.tsx
+++ b/src/pages/Predict.tsx
@@ -50,7 +50,7 @@ export default function Predict() {
 
   // Deep-link: pre-select model from URL params (e.g., from ModelActionMenu)
   const urlModelId = searchParams.get("model_id");
-  const urlSource = searchParams.get("source") as "chain" | "bundle" | null;
+  const urlSource = searchParams.get("source") as "chain" | "bundle" | "native_archive" | null;
 
   useEffect(() => {
     if (urlModelId && urlSource && !preselected) {

--- a/src/types/predict.ts
+++ b/src/types/predict.ts
@@ -5,7 +5,7 @@
 export interface AvailableModel {
   id: string;
   name: string;
-  source: "bundle" | "chain";
+  source: "bundle" | "chain" | "native_archive";
   model_class: string;
   dataset_name: string | null;
   metric: string | null;


### PR DESCRIPTION
## Summary
- add an explicit Archive V2 model picker for native Methods replay
- constrain native archive input to CSV/Excel upload with stable non-numeric sample IDs
- retain the existing native owner validation and prevent dataset/paste routes that cannot attest IDs

## Validation
- TypeScript no-emit check
- ESLint on touched files
- 23 targeted Vitest tests
- git diff --check